### PR TITLE
fix selected ids for virtual options

### DIFF
--- a/lib/ClprApi/solr/filters/options_filter.rb
+++ b/lib/ClprApi/solr/filters/options_filter.rb
@@ -22,6 +22,12 @@ module ClprApi
 
         private
 
+        def selected_ids
+          super.map do |value|
+            value.is_a?(Query::VirtualFields::VirtualOption) ? value.id : value
+          end
+        end
+
         def find_option(option_id)
           field.options.find { |option| option.id.to_s == option_id }
         end


### PR DESCRIPTION
when verifying if the option value  is selected or not in 1OptionsFilter`, it was given false when the field values are instance of VirtualOption.

https://github.com/ApexTech/ClprApi/blob/master/lib/ClprApi/solr/filters/options_filter.rb#L19